### PR TITLE
fix: update layout params type to match Next.js 13+ signature

### DIFF
--- a/frontend/src/app/[formId]/layout.tsx
+++ b/frontend/src/app/[formId]/layout.tsx
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
 
 interface FormLayoutProps {
   children: React.ReactNode;
-  params: { formId: string };
+  params: Promise<{ formId: string }>;
 }
 
 export default function FormLayout({ children }: FormLayoutProps) {


### PR DESCRIPTION
- Changed params from { formId: string } to Promise<{ formId: string }>
- Fixes TypeScript error in layout component
- Aligns with Next.js App Router layout requirements