### PR TITLE
feat: hide translate button when hover translation is active

### DIFF
--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -134,21 +134,23 @@ export function LanguageSelector({
               </Select>
             )}
 
-            <Button
-              size="sm"
-              onClick={handleTranslate}
-              disabled={!selectedLanguage || isTranslating || disabled}
-              className="w-full sm:w-auto h-10 sm:h-8"
-            >
-              {isTranslating ? (
-                <>
-                  <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-                  Translating...
-                </>
-              ) : (
-                'Translate Form'
-              )}
-            </Button>
+            {!hoverTranslationEnabled && (
+              <Button
+                size="sm"
+                onClick={handleTranslate}
+                disabled={!selectedLanguage || isTranslating || disabled}
+                className="w-full sm:w-auto h-10 sm:h-8"
+              >
+                {isTranslating ? (
+                  <>
+                    <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+                    Translating...
+                  </>
+                ) : (
+                  'Translate Form'
+                )}
+              </Button>
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
- Only show 'Translate Form' button when hover translation is disabled
- When hover translation is enabled, users interact via touch/hover directly
- Reduces UI clutter and provides clearer interaction model
- Maintains full form translation option only when hover is disabled