### PR TITLE
feat: Fix performance

### DIFF
--- a/backend/app/api/routes/v1/controllers/form.py
+++ b/backend/app/api/routes/v1/controllers/form.py
@@ -12,6 +12,7 @@ from app.api.routes.v1.dto.form import (
     FormFieldCreationDTO,
     FormFieldDTO,
     FormFieldUpdateDTO,
+    FormSaveDTO,
     FormTranslationModel,
     FormUpdateDTO,
     ResponseCreationDTO,
@@ -269,6 +270,33 @@ async def delete_form_field(
 
 
 # Form Response Operations (Public endpoints for form filling)
+@router.post(
+    "/responses/save",
+    response_model=AnswerSessionDTO,
+    status_code=status.HTTP_200_OK,
+)
+async def save_responses(
+    response: Response,
+    save_data: FormSaveDTO,
+    db_session: DBSessionDependency,
+    response_session_id: CurrentAnswerSessionDependency = None,
+):
+    """Save multiple responses at once (Public endpoint for batch saving)"""
+    answer_session = await form_provider.save_responses(
+        db_session=db_session,
+        answer_session_id=UUID(response_session_id)
+        if response_session_id
+        else None,
+        data=save_data,
+    )
+    response.set_cookie(
+        key=ANSWER_SESSION_COOKIE_KEY,
+        value=str(answer_session.id),
+        httponly=True,
+    )
+    return answer_session
+
+
 @router.post(
     "/responses",
     response_model=FieldResponseDTO,

--- a/backend/app/api/routes/v1/dto/form.py
+++ b/backend/app/api/routes/v1/dto/form.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Literal
+from typing import Dict, List, Literal
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -19,6 +19,11 @@ FormFieldType = Literal[
     "Alpha",
     "Alphanum",
 ]
+
+
+class FormSaveDTO(BaseModel):
+    form_id: UUID
+    field_answers: Dict[UUID, str | None]  # field_id -> value
 
 
 class FormTranslationModel(BaseModel):

--- a/backend/app/app.py
+++ b/backend/app/app.py
@@ -10,10 +10,11 @@ from app.core.db.setup import setup_db
 
 DEBUG = get_env("DEBUG", "True") == "True"
 PORT = int(get_env("PORT", "8000")) or 8000
+CORS_ORIGINS = [o.strip() for o in get_env("CORS_ORIGINS", "").split(",")]
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(_: FastAPI):
     # startup
     setup_db()
     yield
@@ -35,7 +36,8 @@ app.add_middleware(
         "http://localhost:3000",
         "https://loslc.tech",
         "https://forms.loslc.tech",
-    ],  # Or ["http://localhost:3000"] for stricter control
+        *CORS_ORIGINS,
+    ],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/app/core/config/env.py
+++ b/backend/app/core/config/env.py
@@ -19,6 +19,7 @@ EnvKey = Literal[
     "PG_PASSWORD",
     "PG_DATABASE",
     "GEMINI_API_KEY",
+    "CORS_ORIGINS",
 ]
 
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -111,6 +111,11 @@ export interface ResponseCreationRequest {
   value: string | null;
 }
 
+export interface FormSaveRequest {
+  form_id: string;
+  field_answers: Record<string, string | null>;
+}
+
 // Translation types
 export type SupportedLanguages = 
   | "English" 

--- a/frontend/src/lib/hooks/useForms.ts
+++ b/frontend/src/lib/hooks/useForms.ts
@@ -164,6 +164,17 @@ export const useSubmitResponse = () => {
   });
 };
 
+export const useSaveResponses = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: formsService.saveResponses,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["session"] });
+    },
+  });
+};
+
 export const useEditResponse = () => {
   const queryClient = useQueryClient();
 

--- a/frontend/src/lib/services/forms.ts
+++ b/frontend/src/lib/services/forms.ts
@@ -1,13 +1,14 @@
 import {
   api,
-  FormDTO,
-  FormFieldDTO,
-  FieldResponseDTO,
-  AnswerSessionDTO,
-  ResponseCreationRequest,
-  MessageResponse,
-  FormTranslationDTO,
-  SupportedLanguages,
+  type FormDTO,
+  type FormFieldDTO,
+  type FieldResponseDTO,
+  type AnswerSessionDTO,
+  type ResponseCreationRequest,
+  type FormSaveRequest,
+  type MessageResponse,
+  type FormTranslationDTO,
+  type SupportedLanguages,
 } from "../api";
 
 export const formsService = {
@@ -40,6 +41,13 @@ export const formsService = {
     return api.post("api/v1/forms/responses", { json: data }).json();
   },
 
+  // Batch save responses
+  saveResponses: async (
+    data: FormSaveRequest,
+  ): Promise<AnswerSessionDTO> => {
+    return api.post("api/v1/forms/responses/save", { json: data }).json();
+  },
+
   editResponse: async (answerId: string, value: string): Promise<void> => {
     return api
       .put(`api/v1/forms/responses/${answerId}`, {
@@ -55,13 +63,13 @@ export const formsService = {
   // Session management
   // Fetch current answer session using cookie (no sessionId required)
   getCurrentAnswerSession: async (): Promise<AnswerSessionDTO> => {
-    return api.get(`api/v1/forms/sessions`).json();
+    return api.get("api/v1/forms/sessions").json();
   },
 
   // Kept for backward compatibility if specific session endpoints are added later
   // Currently not used and backend doesn't expose this route variant
   getAnswerSession: async (): Promise<AnswerSessionDTO> => {
-    return api.get(`api/v1/forms/sessions`).json();
+    return api.get("api/v1/forms/sessions").json();
   },
 
   submitSession: async (


### PR DESCRIPTION
This pull request introduces a new batch save ("autosave") API for form responses, improving both backend and frontend to support efficient saving of multiple field answers at once. The main changes include adding a `/responses/save` endpoint, updating the frontend to use this endpoint for autosave and form submission, and allowing CORS origins to be configured via environment variables.

**Backend: Batch Save Endpoint and CORS Improvements**

- **Batch Save API for Form Responses**
  - Added a new `FormSaveDTO` data model to accept a batch of field answers (`field_answers`) for a given form (`form_id`). [[1]](diffhunk://#diff-f4279c7af9e566c8c80dbb566da6430fc654a6db4f1b191fe395b1d722b4dffcR24-R28) [[2]](diffhunk://#diff-98a8223b67edec70aa5c3c0788714682b0de0fe1cf713945ee0b2d1a2d7b9623R15)
  - Implemented a new `/responses/save` POST endpoint in `form.py` that uses the `FormSaveDTO` for batch saving responses and sets the answer session cookie.
  - Added the `save_responses` method in the form provider to handle batch saving, including validation and upsert logic for each field answer.
- **CORS Configuration**
  - Updated backend to allow CORS origins to be set via the `CORS_ORIGINS` environment variable, making deployment more flexible. [[1]](diffhunk://#diff-b0d04605961118e1404708a752637082a988f3e6c059eaa1b5a2db8d5da42232R13-R17) [[2]](diffhunk://#diff-b0d04605961118e1404708a752637082a988f3e6c059eaa1b5a2db8d5da42232L38-R40) [[3]](diffhunk://#diff-bed27d9e0977681af3c43cdd23db48da4caeef510c13245716a451e63a39d892R22)

**Frontend: Autosave and Submission Refactor**

- **Batch Autosave and Submission**
  - Refactored autosave logic in `FormPage` so that all dirty field values are saved in a single batch API call every 30 seconds, improving efficiency and user experience. ([frontend/src/app/[formId]/page.tsxL240-R273](diffhunk://#diff-cff9b7a3125e0ee7135b5eaaecc7560ff1a6a79ff2a13c7c19adfc6d3b4fbfa7L240-R273))
  - Updated the form submit handler to use the batch save endpoint, ensuring all responses are saved at once before final submission. ([frontend/src/app/[formId]/page.tsxL284-R299](diffhunk://#diff-cff9b7a3125e0ee7135b5eaaecc7560ff1a6a79ff2a13c7c19adfc6d3b4fbfa7L284-R299), [frontend/src/app/[formId]/page.tsxR318-R335](diffhunk://#diff-cff9b7a3125e0ee7135b5eaaecc7560ff1a6a79ff2a13c7c19adfc6d3b4fbfa7R318-R335))
- **API and Hooks Updates**
  - Added `FormSaveRequest` type and `saveResponses` method to the forms service and corresponding React hook (`useSaveResponses`). [[1]](diffhunk://#diff-fc0647beab64e4906eb6a581b0476dba8073601854e616d8ca3345539b0412b8R114-R118) [[2]](diffhunk://#diff-e5a0934a4e3acbd84ba38539bd596844cca8e8f4088710b85bf87f627a102966L3-R11) [[3]](diffhunk://#diff-e5a0934a4e3acbd84ba38539bd596844cca8e8f4088710b85bf87f627a102966R44-R50) [[4]](diffhunk://#diff-aa99f3518954f901a25981b5392c1f9c618efda79ec9d49e2c68865739ac73c5R167-R177)
  - Updated imports and usage to support the new batch save logic. ([frontend/src/app/[formId]/page.tsxL6-R6](diffhunk://#diff-cff9b7a3125e0ee7135b5eaaecc7560ff1a6a79ff2a13c7c19adfc6d3b4fbfa7L6-R6), [frontend/src/app/[formId]/page.tsxR54](diffhunk://#diff-cff9b7a3125e0ee7135b5eaaecc7560ff1a6a79ff2a13c7c19adfc6d3b4fbfa7R54))

**Other Improvements**

- Cleaned up and clarified some backend code for CSV export and answer validation for better maintainability. [[1]](diffhunk://#diff-d8516dad89c05d05ef365b73c1eff5e67738ea1bb4f60baf70485fd5c63306b7L440-R445) [[2]](diffhunk://#diff-d8516dad89c05d05ef365b73c1eff5e67738ea1bb4f60baf70485fd5c63306b7L574-L594) [[3]](diffhunk://#diff-d8516dad89c05d05ef365b73c1eff5e67738ea1bb4f60baf70485fd5c63306b7L607-L613)

These changes collectively improve the efficiency, scalability, and configurability of form response handling in both the backend and frontend.

**References:** [[1]](diffhunk://#diff-98a8223b67edec70aa5c3c0788714682b0de0fe1cf713945ee0b2d1a2d7b9623R15) [[2]](diffhunk://#diff-98a8223b67edec70aa5c3c0788714682b0de0fe1cf713945ee0b2d1a2d7b9623R273-R299) [[3]](diffhunk://#diff-f4279c7af9e566c8c80dbb566da6430fc654a6db4f1b191fe395b1d722b4dffcR24-R28) [[4]](diffhunk://#diff-d8516dad89c05d05ef365b73c1eff5e67738ea1bb4f60baf70485fd5c63306b7R513-R547) [[5]](diffhunk://#diff-b0d04605961118e1404708a752637082a988f3e6c059eaa1b5a2db8d5da42232R13-R17) [[6]](diffhunk://#diff-b0d04605961118e1404708a752637082a988f3e6c059eaa1b5a2db8d5da42232L38-R40) [[7]](diffhunk://#diff-bed27d9e0977681af3c43cdd23db48da4caeef510c13245716a451e63a39d892R22) [frontend/src/app/[formId]/page.tsxL240-R273](diffhunk://#diff-cff9b7a3125e0ee7135b5eaaecc7560ff1a6a79ff2a13c7c19adfc6d3b4fbfa7L240-R273), [frontend/src/app/[formId]/page.tsxL284-R299](diffhunk://#diff-cff9b7a3125e0ee7135b5eaaecc7560ff1a6a79ff2a13c7c19adfc6d3b4fbfa7L284-R299), [frontend/src/app/[formId]/page.tsxR318-R335](diffhunk://#diff-cff9b7a3125e0ee7135b5eaaecc7560ff1a6a79ff2a13c7c19adfc6d3b4fbfa7R318-R335), [[8]](diffhunk://#diff-fc0647beab64e4906eb6a581b0476dba8073601854e616d8ca3345539b0412b8R114-R118) [[9]](diffhunk://#diff-e5a0934a4e3acbd84ba38539bd596844cca8e8f4088710b85bf87f627a102966L3-R11) [[10]](diffhunk://#diff-e5a0934a4e3acbd84ba38539bd596844cca8e8f4088710b85bf87f627a102966R44-R50) [[11]](diffhunk://#diff-aa99f3518954f901a25981b5392c1f9c618efda79ec9d49e2c68865739ac73c5R167-R177) [frontend/src/app/[formId]/page.tsxL6-R6](diffhunk://#diff-cff9b7a3125e0ee7135b5eaaecc7560ff1a6a79ff2a13c7c19adfc6d3b4fbfa7L6-R6), [frontend/src/app/[formId]/page.tsxR54](diffhunk://#diff-cff9b7a3125e0ee7135b5eaaecc7560ff1a6a79ff2a13c7c19adfc6d3b4fbfa7R54), [[12]](diffhunk://#diff-d8516dad89c05d05ef365b73c1eff5e67738ea1bb4f60baf70485fd5c63306b7L440-R445) [[13]](diffhunk://#diff-d8516dad89c05d05ef365b73c1eff5e67738ea1bb4f60baf70485fd5c63306b7L574-L594) [[14]](diffhunk://#diff-d8516dad89c05d05ef365b73c1eff5e67738ea1bb4f60baf70485fd5c63306b7L607-L613)